### PR TITLE
Fix theme toggler icon

### DIFF
--- a/website/src/components/SVG.tsx
+++ b/website/src/components/SVG.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PomatezSVG from "../assets/icons/pomatez.svg";
 import DownloadSVG from "../assets/icons/download.svg";
 import SunnySVG from "../assets/icons/sunny.svg";
@@ -10,38 +10,45 @@ import LinuxSVG from "../assets/icons/linux.svg";
 import SnapStoreSVG from "../assets/icons/snap-store.svg";
 import TuxSVG from "../assets/icons/tux.svg";
 import ArrowBackSVG from "../assets/icons/arrow-back.svg";
+import { useIsBrowser } from "../hooks/useIsBrowser";
 
 type Props = {
 	name?: string;
 };
 
 export const SVG: React.FC<Props> = ({ name }) => {
-	switch (name) {
-		case "pomatez":
-			return <PomatezSVG />;
-		case "download":
-			return <DownloadSVG />;
-		case "sunny":
-			return <SunnySVG />;
-		case "moon":
-			return <MoonSVG />;
-		case "github":
-			return <GithubSVG />;
-		case "windows":
-			return <WindowSVG />;
-		case "apple":
-			return <AppleSVG />;
-		case "linux":
-			return <LinuxSVG />;
-		case "snap-store":
-			return <SnapStoreSVG />;
-		case "tux":
-			return <TuxSVG />;
-		case "arrow-back":
-			return <ArrowBackSVG />;
-		default:
-			return <PomatezSVG />;
+	const isBrowser = useIsBrowser();
+
+	if (isBrowser) {
+		switch (name) {
+			case "pomatez":
+				return <PomatezSVG />;
+			case "download":
+				return <DownloadSVG />;
+			case "sunny":
+				return <SunnySVG />;
+			case "moon":
+				return <MoonSVG />;
+			case "github":
+				return <GithubSVG />;
+			case "windows":
+				return <WindowSVG />;
+			case "apple":
+				return <AppleSVG />;
+			case "linux":
+				return <LinuxSVG />;
+			case "snap-store":
+				return <SnapStoreSVG />;
+			case "tux":
+				return <TuxSVG />;
+			case "arrow-back":
+				return <ArrowBackSVG />;
+			default:
+				return <PomatezSVG />;
+		}
 	}
+
+	return null;
 };
 
 export default React.memo(SVG);

--- a/website/src/hooks/useIsBrowser.ts
+++ b/website/src/hooks/useIsBrowser.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export const useIsBrowser = () => {
+	const [isBrowser, setIsBrowser] = useState(false);
+
+	useEffect(() => {
+		setIsBrowser(true);
+		return () => setIsBrowser(false);
+	}, []);
+
+	return isBrowser;
+};


### PR DESCRIPTION
Gatsby had an issue rendering the SVG properly at build time which meant the icon wouldn't display properly until it had been toggled. Forcing it to render on the client-side seems like an acceptable workaround.