### PR TITLE
chore(ci): upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn ${{ matrix.yarn-task }}
       # Possibly set up some basic unit testing just to make sure parts render and none of the libraries are straight up breaking
-
+      - uses: actions/upload-artifact@v2
+        with:
+         name: built-app-${{ matrix.os }}
+         path: |
+           app/main/dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            name: linux
             yarn-task: build:linux
           - os: ubuntu-latest
+            name: snap
             yarn-task: build:snap
           - os: macos-latest
-            yarn-task: build:mac
+            name: mac
+            yarn-task: build:
+            name: win
           - os: windows-latest
             yarn-task: build:win
 
@@ -42,6 +46,6 @@ jobs:
       # Possibly set up some basic unit testing just to make sure parts render and none of the libraries are straight up breaking
       - uses: actions/upload-artifact@v2
         with:
-         name: built-app-${{ matrix.os }}
+         name: built-app-${{ matrix.name }}
          path: |
            app/main/dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,15 +30,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-      - name: Cache .yarn/cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('package.json') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'yarn'
       - name: Install NPM Packages
         run: |
-          yarn install --immutable
+          yarn install --immutable --network-timeout 120000
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
             yarn-task: build:snap
           - os: macos-latest
             name: mac
-            yarn-task: build:
-            name: win
+            yarn-task: build:win
           - os: windows-latest
+            name: win
             yarn-task: build:win
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             yarn-task: build:snap
           - os: macos-latest
             name: mac
-            yarn-task: build:win
+            yarn-task: build:mac
           - os: windows-latest
             name: win
             yarn-task: build:win

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
         with:
          name: built-app-${{ matrix.name }}
          path: |
-           app/main/dist/*
+           app/main/dist/*.*


### PR DESCRIPTION
Helps with being able to test in vm's and such without having to compile locally for each.