### PR TITLE
chore(ci): bump version for main package.json & fix release issue

### DIFF
--- a/app/main/package.json
+++ b/app/main/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pomatez",
-	"version": "1.2.1",
+	"version": "1.2.0",
 	"private": true,
 	"license": "MIT",
 	"main": "./build/main.js",
@@ -100,7 +100,7 @@
 		"@types/uuid": "^8.3.0",
 		"babel-core": "^6.26.3",
 		"babel-jest": "^26.6.3",
-		"electron": "11.5.0",
+		"electron": "10.1.2",
 		"electron-builder": "^22.8.0",
 		"regenerator-runtime": "^0.13.7",
 		"ts-jest": "^26.5.1"

--- a/app/main/package.json
+++ b/app/main/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pomatez",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"private": true,
 	"license": "MIT",
 	"main": "./build/main.js",

--- a/app/main/package.json
+++ b/app/main/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pomatez",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"private": true,
 	"license": "MIT",
 	"main": "./build/main.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,20 @@
 {
+	"release-type": "node",
 	"packages": {
-		".": {
-			"release-type": "node"
-		}
+		".": {}
 	},
+	"extra-files": [
+		{
+			"type": "json",
+			"path": "app/main/package.json",
+			"jsonpath": "$.version"
+		},
+		{
+			"type": "json",
+			"path": "app/renderer/package.json",
+			"jsonpath": "$.version"
+		}
+	],
 	"bootstrap-sha": "c79279b136557b39d9d94038a879e681c1065ea1",
 	"changelog-sections": [
 		{ "type": "feat", "section": "Features ✨" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
 	"packages": {
 		".": {}
 	},
+	"draft": true,
 	"extra-files": [
 		{
 			"type": "json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9378,10 +9378,10 @@ electron-updater@^4.3.4:
     lodash.isequal "^4.5.0"
     semver "^7.3.2"
 
-electron@11.5.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.5.0.tgz#f1650543b9d8f2047d3807755bdb120153ed210f"
-  integrity sha512-WjNDd6lGpxyiNjE3LhnFCAk/D9GIj1rU3GSDealVShhkkkPR3Vh4q8ErXGDl1OAO/faomVa10KoFPUN/pLbNxg==
+electron@10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-10.1.2.tgz#30b6fd7669f8daf08c56219a61dfa053fa2b0c70"
+  integrity sha512-SvN8DcKCmPZ0UcQSNAJBfaUu+LGACqtRhUn1rW0UBLHgdbbDM76L0GU5/XGQEllH5pu5bwlCZwax3srzIl+Aeg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
This is a temporary fix to build with the correct version number while I re-configure the npm project. It seems setting the release-type on a lerna project needs a bit more configuration.