### PR TITLE
fix: data loss

### DIFF
--- a/app/renderer/src/hooks/useTargetOutside.ts
+++ b/app/renderer/src/hooks/useTargetOutside.ts
@@ -5,10 +5,12 @@ interface TargetOutside {
 	eventType?: string;
 }
 
-export const useTargetOutside = ({
-	ref,
-	eventType = "click",
-}: TargetOutside) => {
+/**
+ * If you want to listen to clicks outside the element set eventType to 'click'
+ * @param ref
+ * @param eventType
+ */
+export const useTargetOutside = ({ ref, eventType }: TargetOutside) => {
 	const [state, setState] = useState<any>();
 
 	useLayoutEffect(() => {
@@ -31,11 +33,11 @@ export const useTargetOutside = ({
 		}
 
 		if (state) {
-			document.addEventListener(eventType, outsideTarget);
+			if (eventType) document.addEventListener(eventType, outsideTarget);
 			document.addEventListener("keydown", closeOnEscape);
 		}
 		return () => {
-			document.removeEventListener(eventType, outsideTarget);
+			if (eventType) document.removeEventListener(eventType, outsideTarget);
 			document.removeEventListener("keydown", closeOnEscape);
 		};
 	}, [state, ref, eventType]);

--- a/app/renderer/src/routes/Tasks/TaskFormButton.tsx
+++ b/app/renderer/src/routes/Tasks/TaskFormButton.tsx
@@ -37,14 +37,18 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
 					formRef.current.reset();
 				}
 			}
+			setOpen(false);
 
 			return true;
 		},
-		[onSubmit]
+		[onSubmit, setOpen]
 	);
 
 	useEffect(() => {
 		if (isOpen) {
+			if (!forList && formRef.current) {
+				formRef?.current?.scrollIntoView({ block: "center" });
+			}
 			if (forList) {
 				if (inputRef.current) {
 					inputRef.current.focus();
@@ -64,7 +68,7 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
 					areaRef.current.onkeypress = (e: KeyboardEvent) => {
 						if (e.keyCode === 10 && areaRef.current) {
 							e.preventDefault();
-							if (doSubmit(areaRef.current))
+							if (doSubmit(areaRef.current) && areaRef?.current?.style?.height)
 								areaRef.current.style.height = "inherit";
 						}
 					};


### PR DESCRIPTION
This should fix #258 

Though @roldanjr might want to check if the new behavior is acceptable.

I wanted to make it snap to the bottom only If out of view but that was harder than expected due to the bottom being scrollable and semi transparent it causes it to snap where its not visible
![image](https://user-images.githubusercontent.com/3209834/166085487-00e60d41-b107-43e9-909c-392feb5d87c1.png)


So the result is you can no longer close tasks by clicking off them (checked and its the same as apps like todoist) and it will snap the new card to the center of the div 
![image](https://user-images.githubusercontent.com/3209834/166085558-f7358ffe-b732-4b53-a402-ef0871523fe7.png)
