### PR TITLE
fix: link new window

### DIFF
--- a/app/main/src/main.ts
+++ b/app/main/src/main.ts
@@ -89,6 +89,11 @@ function createMainWindow() {
 	// Open the DevTools.
 	if (isDev) win.webContents.openDevTools({ mode: "detach" });
 
+	win.webContents.setWindowOpenHandler((details) => {
+		shell.openExternal(details.url);
+		return { action: "deny" };
+	});
+
 	win.loadURL(
 		!onProduction
 			? "http://localhost:3000"

--- a/app/renderer/src/routes/Tasks/TaskDetails/MDPreviewer.tsx
+++ b/app/renderer/src/routes/Tasks/TaskDetails/MDPreviewer.tsx
@@ -18,6 +18,7 @@ const MDPreviewer: React.FC<Props> = ({ description, onClick }) => {
 		>
 			<ReactMarkdown
 				escapeHtml={false}
+				linkTarget={"_blank"}
 				source={
 					description ? description : "Add a more detailed description..."
 				}

--- a/app/renderer/src/routes/Tasks/TaskDetails/MDPreviewer.tsx
+++ b/app/renderer/src/routes/Tasks/TaskDetails/MDPreviewer.tsx
@@ -14,7 +14,13 @@ const MDPreviewer: React.FC<Props> = ({ description, onClick }) => {
 		<StyledDescriptionPreviewer
 			className="md-previewer"
 			hasValue={description != null}
-			onClick={onClick}
+			onClick={(event) => {
+				// Because it doesn't seem to let you reffer to target as HTMLDivElement, only currentElement which is wrong
+				let target: any = event?.target;
+				if (onClick && target?.tagName !== "A") {
+					onClick(event);
+				}
+			}}
 		>
 			<ReactMarkdown
 				escapeHtml={false}


### PR DESCRIPTION
Fixes #257

Links with the _blank target will now automatically open in a new browser as well as markdown target has been set to _blank