### PR TITLE
chore(ci): stop upload of duplicate files [skip ci]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           upload_url: ${{ needs.release-please.outputs.upload_url }}
           asset_path: |
-            app/main/dist/*.yml
+            app/main/dist/latest*
             app/main/dist/*.deb
             app/main/dist/*.rpm
             app/main/dist/*.dmg


### PR DESCRIPTION
This is to fix the clashing files on release. I have tested it on my own fork and it works fine.