### PR TITLE
Set Application Menu  to Fix Mac Shortcuts

### DIFF
--- a/app/main/src/main.ts
+++ b/app/main/src/main.ts
@@ -55,6 +55,12 @@ const trayIcon = path.join(__dirname, "./assets/tray-dark.png");
 
 const onlySingleInstance = app.requestSingleInstanceLock();
 
+const applicationMenu = Menu.buildFromTemplate([
+  { role: isMac ? "appMenu" : "fileMenu" },
+  { role: "editMenu" },
+]);
+Menu.setApplicationMenu(applicationMenu);
+
 const getFrameHeight = () => {
   if (isWindow()) {
     return 502;
@@ -203,14 +209,8 @@ function createMainWindow() {
     win = null;
   });
 
-  Menu.setApplicationMenu(applicationMenu);
   createContextMenu(win);
 }
-
-const applicationMenu = Menu.buildFromTemplate([
-  { role: isMac ? "appMenu" : "fileMenu" },
-  { role: "editMenu" },
-]);
 
 const trayTooltip = "Just click to restore.";
 

--- a/app/main/src/main.ts
+++ b/app/main/src/main.ts
@@ -36,6 +36,7 @@ import { activateUser } from "./helpers/analytics";
 import store from "./store";
 import isDev from "electron-is-dev";
 const isWin = process.platform === "win32";
+const isMac = process.platform === "darwin";
 
 import "v8-compile-cache";
 import {
@@ -53,8 +54,6 @@ const notificationIcon = path.join(
 const trayIcon = path.join(__dirname, "./assets/tray-dark.png");
 
 const onlySingleInstance = app.requestSingleInstanceLock();
-
-Menu.setApplicationMenu(null);
 
 const getFrameHeight = () => {
   if (isWindow()) {
@@ -204,8 +203,14 @@ function createMainWindow() {
     win = null;
   });
 
+  Menu.setApplicationMenu(applicationMenu);
   createContextMenu(win);
 }
+
+const applicationMenu = Menu.buildFromTemplate([
+  { role: isMac ? "appMenu" : "fileMenu" },
+  { role: "editMenu" },
+]);
 
 const trayTooltip = "Just click to restore.";
 

--- a/app/main/src/main.ts
+++ b/app/main/src/main.ts
@@ -55,10 +55,9 @@ const trayIcon = path.join(__dirname, "./assets/tray-dark.png");
 
 const onlySingleInstance = app.requestSingleInstanceLock();
 
-const applicationMenu = Menu.buildFromTemplate([
-  { role: isMac ? "appMenu" : "fileMenu" },
-  { role: "editMenu" },
-]);
+const applicationMenu = isMac
+  ? Menu.buildFromTemplate([{ role: "appMenu" }, { role: "editMenu" }])
+  : null;
 Menu.setApplicationMenu(applicationMenu);
 
 const getFrameHeight = () => {


### PR DESCRIPTION
# Problem

Keyboard shortcuts such as cut, copy, paste etc are currently not working on Mac, but do work when clicking on their respective options via the context menu.

It looks thats because this functionality requires the Mac `Edit` application menu which currently does not exist (See this issue https://github.com/electron/electron/issues/3787).

# Solution

Created this PR to add the app and edit menu's (App Menu with just `Quit` option is there currently by default).

Only added the menus for Mac because it doesn't look like Linux has this issue (Haven't tried windows yet but guessing its the same) and aside from the edit controls that already exist in the context menu, it wouldn't really be adding anything useful.

Used the `appMenu` role option here so that it creates the default Mac App menu. All the other options seem to work correctly:
<img width="361" alt="Screenshot 2023-04-18 at 9 29 34 PM" src="https://user-images.githubusercontent.com/7366880/232735207-82e6c598-4d2b-44b4-914c-a38ff616616d.png">

It also adds a `About Pomatez` button which shows:
<img width="454" alt="Screenshot 2023-04-18 at 9 35 11 PM" src="https://user-images.githubusercontent.com/7366880/232736295-dc4c51ee-8c7d-4e7b-a5bf-25b3722188dc.png">

Edit Menu:
<img width="365" alt="Screenshot 2023-04-18 at 9 31 44 PM" src="https://user-images.githubusercontent.com/7366880/232735320-efb73353-77c6-4149-aa91-658ff487d980.png">

# Tests

**Manual**
- [x] Build Mac app and ensure that App & Edit Menu show up for Mac and make sure all the menu options work
- [x] Build Linux app (tested on Ubuntu) and ensure no App/File or edit menu appear
- [ ] Build Windows app and ensure no App/File or edit menu appear

*Still need to find a Windows to test on